### PR TITLE
fix: add repository reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "yarn build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Gerrit0/typedoc-plugin-mdn-links.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Gerrit0/typedoc-plugin-mdn-links/issues"
   }
 }


### PR DESCRIPTION
Without such a reference, it is not indicated on https://www.npmjs.com/package/typedoc-plugin-mdn-links where the source code of this package resides.

![image](https://user-images.githubusercontent.com/2505178/151115070-e64b64ba-c9b4-40be-92e7-43258627c8e6.png)


Format/structure according to NPM docs:
* https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository
* https://docs.npmjs.com/cli/v8/configuring-npm/package-json#bugs