### PR TITLE
fix: uncomment AsyncGenerator and AsyncGeneratorFunction

### DIFF
--- a/src/globalObjects.ts
+++ b/src/globalObjects.ts
@@ -78,8 +78,9 @@ const knownGlobalObjects = new Set([
     "Generator",
     "GeneratorFunction",
     "AsyncFunction",
-    // "AsyncGenerator", // No file on MDN yet
-    // "AsyncGeneratorFunction", // No file on MDN yet
+    "AsyncGenerator",
+    "AsyncGeneratorFunction",
+    // "IteratorResult", No file on MDN yet https://github.com/mdn/content/issues/23131
 
     // Reflection
     "Reflect",


### PR DESCRIPTION
These have pages on MDN now so uncomment them to enable their use.

Also adds a place holder for `IteratorResult` - hopefully this will get added and can be linked too - https://github.com/mdn/content/issues/23131