### PR TITLE
Add dist/typescript.js to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dist/dom.js",
     "dist/globalObjects.js",
     "dist/index.js",
+    "dist/typescript.js",
     "dist/webaudio.js"
   ],
   "peerDependencies": {


### PR DESCRIPTION
With v3.0.2 the following error occurs; "Error: Cannot find module './typescript'" This is most likely due to the file not being packaged and published to NPM